### PR TITLE
Hashlib SHA-1 is considered deprecated. We should be using SHA-2 now.

### DIFF
--- a/flask_xsrf.py
+++ b/flask_xsrf.py
@@ -157,7 +157,7 @@ class XSRFToken(object):
       self.current_time = int(current_time)
 
   def _digest_maker(self):
-    return hmac.new(self.secret, digestmod=hashlib.sha1)
+    return hmac.new(self.secret, digestmod=hashlib.sha256)
 
   def generate_token_string(self, action=None):
     """Generate a hash of the given token contents that can be verified.


### PR DESCRIPTION
Hey Gregory.

I've been using your flask-xsrf project while developing a project to learn Python and noticed that you are using SHA-1 which is now considered a deprecated hashlib.

I've done a simple change to use SHA-2 (digest size 256). All tests are passing and I've used it with this change without issues.

Thank you :)